### PR TITLE
Pcre2 concat

### DIFF
--- a/src/Rule.cpp
+++ b/src/Rule.cpp
@@ -139,6 +139,8 @@ void regexbench::concatRules(std::vector<Rule> &rules) {
   }
 
   rules.clear();
-  concatResult[concatResult.size()-1] = '\0';
+
+  // call resize to remove the tailing '|' character
+  concatResult.resize(concatResult.size() - 1);
   rules.emplace_back(Rule(concatResult, 0));
 }

--- a/src/Rule.cpp
+++ b/src/Rule.cpp
@@ -23,8 +23,19 @@ Rule::Rule(const std::string &rule) {
   parseRule(rule, colon_pos + 1);
 }
 
-Rule::Rule(const std::string &rule, size_t ruleid) : id(ruleid) {
+Rule::Rule(const std::string &rule, size_t ruleid, uint32_t ops) : id(ruleid) {
   parseRule(rule, 0);
+  if (ops)
+    setOptions(ops);
+}
+
+void Rule::setOptions(uint32_t pcre2ops) {
+  if (pcre2ops & PCRE2_CASELESS)
+    mods.set(MOD_CASELESS);
+  if (pcre2ops & PCRE2_MULTILINE)
+    mods.set(MOD_MULTILINE);
+  if (pcre2ops & PCRE2_DOTALL)
+    mods.set(MOD_DOTALL);
 }
 
 uint32_t Rule::getPCRE2Options() const {
@@ -132,15 +143,17 @@ std::vector<Rule> regexbench::loadRules(std::istream &is) {
 
 void regexbench::concatRules(std::vector<Rule> &rules) {
   std::string concatResult;
+  uint32_t ops = 0;
   for (const auto &rule : rules) {
     concatResult += "(";
     concatResult += rule.getRegexp();
     concatResult += ")|";
+    ops |= rule.getPCRE2Options();
   }
 
   rules.clear();
 
   // call resize to remove the tailing '|' character
   concatResult.resize(concatResult.size() - 1);
-  rules.emplace_back(Rule(concatResult, 0));
+  rules.emplace_back(Rule(concatResult, 0, ops));
 }

--- a/src/Rule.cpp
+++ b/src/Rule.cpp
@@ -129,3 +129,16 @@ std::vector<Rule> regexbench::loadRules(std::istream &is) {
   }
   return rules;
 }
+
+void regexbench::concatRules(std::vector<Rule> &rules) {
+  std::string concatResult;
+  for (const auto &rule : rules) {
+    concatResult += "(";
+    concatResult += rule.getRegexp();
+    concatResult += ")|";
+  }
+
+  rules.clear();
+  concatResult[concatResult.size()-1] = '\0';
+  rules.emplace_back(Rule(concatResult, 0));
+}

--- a/src/Rule.h
+++ b/src/Rule.h
@@ -40,8 +40,9 @@ private:
   std::bitset<NMODS> mods;
 };
 
-  std::vector<Rule> loadRules(std::istream &);
-  void concatRules(std::vector<Rule> &);
+std::vector<Rule> loadRules(std::istream &);
+void concatRules(std::vector<Rule> &);
+
 } // namespace regexbench
 
 #endif

--- a/src/Rule.h
+++ b/src/Rule.h
@@ -21,7 +21,7 @@ public:
   Rule(const Rule &) = default;
   Rule(Rule &&) = default;
   explicit Rule(const std::string &);
-  explicit Rule(const std::string &, size_t);
+  explicit Rule(const std::string &, size_t, uint32_t = 0);
   ~Rule() = default;
   Rule &operator=(const Rule &) = default;
   Rule &operator=(Rule &&) = default;
@@ -34,6 +34,7 @@ public:
 
 private:
   void parseRule(const std::string &, size_t);
+  void setOptions(uint32_t);
 
   size_t id;
   std::string regexp;

--- a/src/Rule.h
+++ b/src/Rule.h
@@ -40,8 +40,8 @@ private:
   std::bitset<NMODS> mods;
 };
 
-std::vector<Rule> loadRules(std::istream &);
-
+  std::vector<Rule> loadRules(std::istream &);
+  void concatRules(std::vector<Rule> &);
 } // namespace regexbench
 
 #endif

--- a/src/regexbench.cpp
+++ b/src/regexbench.cpp
@@ -43,6 +43,7 @@ int main(int argc, const char *argv[]) {
     switch (args.engine) {
     case ENGINE_HYPERSCAN:
       engine = std::make_unique<regexbench::HyperscanEngine>();
+      engine->compile(loadRules(args.rule_file));
       break;
     case ENGINE_PCRE2:
       engine = std::make_unique<regexbench::PCRE2Engine>();

--- a/src/regexbench.cpp
+++ b/src/regexbench.cpp
@@ -28,7 +28,8 @@ struct Arguments {
   std::string rule_file;
   std::string pcap_file;
   EngineType engine;
-  long repeat;
+  int32_t repeat;
+  uint32_t pcre2_concat;
 };
 
 static bool endsWith(const std::string &, const char *);
@@ -42,11 +43,16 @@ int main(int argc, const char *argv[]) {
     switch (args.engine) {
     case ENGINE_HYPERSCAN:
       engine = std::make_unique<regexbench::HyperscanEngine>();
-      engine->compile(loadRules(args.rule_file));
       break;
     case ENGINE_PCRE2:
       engine = std::make_unique<regexbench::PCRE2Engine>();
-      engine->compile(loadRules(args.rule_file));
+      if (!args.pcre2_concat)
+        engine->compile(loadRules(args.rule_file));
+      else {
+        auto rules = loadRules(args.rule_file);
+        concatRules(rules);
+        engine->compile(rules);
+      }
       break;
     case ENGINE_RE2:
       engine = std::make_unique<regexbench::RE2Engine>();
@@ -135,8 +141,12 @@ Arguments parse_options(int argc, const char *argv[]) {
     "Matching engine to run.");
   optargs.add_options()(
     "repeat,r",
-    po::value<long>(&args.repeat)->default_value(1),
+    po::value<int32_t>(&args.repeat)->default_value(1),
     "Repeat pcap multiple times.");
+  optargs.add_options()(
+    "concat,c",
+    po::value<uint32_t>(&args.pcre2_concat)->default_value(0),
+    "Concatenate PCRE2 rules.");
 
   po::options_description cliargs;
   cliargs.add(posargs).add(optargs);


### PR DESCRIPTION
Add rule concatenation in pcre2. The command line option is turned off by default, to turn on specify `-c 1`.
