### PR TITLE
Pcre2jit

### DIFF
--- a/src/PCRE2Engine.cpp
+++ b/src/PCRE2Engine.cpp
@@ -1,6 +1,6 @@
 #include <rematch/compile.h>
 #include "PCRE2Engine.h"
-#include <iostream>
+
 using namespace regexbench;
 
 void PCRE2Engine::compile(const std::vector<Rule> &rules) {
@@ -34,8 +34,6 @@ void  PCRE2JITEngine::compile(const std::vector<Rule> &rules) {
   PCRE2_SIZE erroffset = 0;
   int errcode = 0;
 
-  // pcre2_config();
-  
   for (const auto &rule : rules) {
     auto re = pcre2_compile(reinterpret_cast<PCRE2_SPTR>(rule.getRegexp().data()),
                          PCRE2_ZERO_TERMINATED, rule.getPCRE2Options(),
@@ -44,9 +42,6 @@ void  PCRE2JITEngine::compile(const std::vector<Rule> &rules) {
       throw std::runtime_error("PCRE2 Compile failed.");
 
     errcode = pcre2_jit_compile(re, PCRE2_JIT_COMPLETE);
-    if (errcode != PCRE2_ERROR_JIT_BADOPTION)
-      std::cout << "errcode " << errcode << " not support " << PCRE2_ERROR_JIT_BADOPTION << "\n";
-    
     if (errcode < 0)
       throw std::runtime_error("PCRE2 JIT compile failed.");
 

--- a/src/PCRE2Engine.h
+++ b/src/PCRE2Engine.h
@@ -37,8 +37,7 @@ public:
   virtual ~PCRE2JITEngine() = default;
 
   virtual void compile(const std::vector<Rule> &);
-  // virtual bool match(const char *, size_t);
-};  
+};
 
 } // namespace regexbench
 

--- a/src/PCRE2Engine.h
+++ b/src/PCRE2Engine.h
@@ -17,7 +17,7 @@ public:
   virtual void compile(const std::vector<Rule> &);
   virtual bool match(const char *, size_t);
 
-private:
+protected:
   struct PCRE2_DATA {
     pcre2_code *re;
     pcre2_match_data *mdata;
@@ -30,6 +30,15 @@ private:
 
   std::vector<std::unique_ptr<PCRE2_DATA>> res;
 };
+
+class PCRE2JITEngine : public PCRE2Engine {
+public:
+  PCRE2JITEngine() = default;
+  virtual ~PCRE2JITEngine() = default;
+
+  virtual void compile(const std::vector<Rule> &);
+  // virtual bool match(const char *, size_t);
+};  
 
 } // namespace regexbench
 

--- a/src/match.cpp
+++ b/src/match.cpp
@@ -11,7 +11,6 @@
 #include "PcapSource.h"
 #include "regexbench.h"
 
-#include <iostream>
 using namespace regexbench;
 
 MatchResult regexbench::match(Engine &engine,
@@ -76,7 +75,6 @@ MatchResult regexbench::match(Engine &engine,
     }
   }
   getrusage(RUSAGE_SELF, &end);
-  std::cout << "mem usage " << end.ru_maxrss / 1024 << "k\n";
   timersub(&(end.ru_utime), &(begin.ru_utime), &result.udiff);
   timersub(&(end.ru_stime), &(begin.ru_stime), &result.sdiff);
   return result;

--- a/src/match.cpp
+++ b/src/match.cpp
@@ -11,6 +11,7 @@
 #include "PcapSource.h"
 #include "regexbench.h"
 
+#include <iostream>
 using namespace regexbench;
 
 MatchResult regexbench::match(Engine &engine,
@@ -75,6 +76,7 @@ MatchResult regexbench::match(Engine &engine,
     }
   }
   getrusage(RUSAGE_SELF, &end);
+  std::cout << "mem usage " << end.ru_maxrss / 1024 << "k\n";
   timersub(&(end.ru_utime), &(begin.ru_utime), &result.udiff);
   timersub(&(end.ru_stime), &(begin.ru_stime), &result.sdiff);
   return result;

--- a/src/regexbench.cpp
+++ b/src/regexbench.cpp
@@ -109,8 +109,7 @@ int main(int argc, const char *argv[]) {
 
   struct rusage stat;
   getrusage(RUSAGE_SELF, &stat);
-  std::cout << "mem usage " << stat.ru_maxrss / 1024 << "k ixrss " << stat.ru_ixrss << " stack " << stat.ru_isrss << " data " << stat.ru_idrss << "\n";
-  
+  std::cout << stat.ru_maxrss / 1000 << " kB\n";
   return EXIT_SUCCESS;
 }
 

--- a/src/regexbench.cpp
+++ b/src/regexbench.cpp
@@ -37,6 +37,7 @@ struct Arguments {
 static bool endsWith(const std::string &, const char *);
 static std::vector<regexbench::Rule> loadRules(const std::string &);
 static Arguments parse_options(int argc, const char *argv[]);
+static void compilePCRE2(const Arguments &, std::unique_ptr<regexbench::Engine> &);
 
 int main(int argc, const char *argv[]) {
   try {
@@ -49,17 +50,11 @@ int main(int argc, const char *argv[]) {
       break;
     case ENGINE_PCRE2:
       engine = std::make_unique<regexbench::PCRE2Engine>();
-      if (!args.pcre2_concat)
-        engine->compile(loadRules(args.rule_file));
-      else {
-        auto rules = loadRules(args.rule_file);
-        concatRules(rules);
-        engine->compile(rules);
-      }
+      compilePCRE2(args, engine);
       break;
     case ENGINE_PCRE2JIT:
       engine = std::make_unique<regexbench::PCRE2JITEngine>();
-      engine->compile(loadRules(args.rule_file));
+      compilePCRE2(args, engine);
       break;
     case ENGINE_RE2:
       engine = std::make_unique<regexbench::RE2Engine>();
@@ -200,4 +195,15 @@ Arguments parse_options(int argc, const char *argv[]) {
     std::exit(EXIT_FAILURE);
   }
   return args;
+}
+
+static void compilePCRE2(const Arguments &args,
+                         std::unique_ptr<regexbench::Engine> &engine) {
+  if (!args.pcre2_concat)
+    engine->compile(loadRules(args.rule_file));
+  else {
+    auto rules = loadRules(args.rule_file);
+    concatRules(rules);
+    engine->compile(rules);
+  }
 }


### PR DESCRIPTION
The pcre2jit has been implemented. One can specify `-e pcre2jit` in the command line to choose `pcre2jit` engine. To handle the case that `pcre2` not support `jit`, regexbench simple halt and print error info. The behavior is different from `pcre2` library where it continues compiling rules and executing without `jit`. The reason we design this way is that we want to distinguish `pcre2jit` with `pcre2` so there is no overlapping between two engines. 
