### PR TITLE
Refine output

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -42,7 +42,7 @@ if(RE2_INCLUDE_DIR)
 endif()
 
 add_executable(regexbench
-  match.cpp PcapSource.cpp regexbench.cpp Rule.cpp Session.cpp
+  util.cpp match.cpp PcapSource.cpp regexbench.cpp Rule.cpp Session.cpp
   ${ENGINE_SRCS})
 target_link_libraries(regexbench
   ${Boost_LIBRARIES} ${PCAP_LIB})

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -42,7 +42,7 @@ if(RE2_INCLUDE_DIR)
 endif()
 
 add_executable(regexbench
-  util.cpp match.cpp PcapSource.cpp regexbench.cpp Rule.cpp Session.cpp
+  match.cpp PcapSource.cpp regexbench.cpp Rule.cpp Session.cpp
   ${ENGINE_SRCS})
 target_link_libraries(regexbench
   ${Boost_LIBRARIES} ${PCAP_LIB})

--- a/src/regexbench.cpp
+++ b/src/regexbench.cpp
@@ -39,6 +39,7 @@ struct Arguments {
   EngineType engine;
   int32_t repeat;
   uint32_t pcre2_concat;
+  std::string output_file;
 };
 
 static bool endsWith(const std::string &, const char *);
@@ -127,7 +128,7 @@ int main(int argc, const char *argv[]) {
 
     std::ostringstream buf;
     write_json(buf, pt, false);
-    std::ofstream outputFile("JsonOutput.txt");
+    std::ofstream outputFile(args.output_file);
     outputFile << buf.str();
 
     for (const auto &it : reportFields) {
@@ -179,7 +180,10 @@ Arguments parse_options(int argc, const char *argv[]) {
   optargs.add_options()(
       "concat,c", po::value<uint32_t>(&args.pcre2_concat)->default_value(0),
       "Concatenate PCRE2 rules.");
-
+  optargs.add_options()(
+      "output,o",
+      po::value<std::string>(&args.output_file)->default_value("output.json"),
+      "Output JSON file.");
   po::options_description cliargs;
   cliargs.add(posargs).add(optargs);
   po::variables_map vm;

--- a/src/regexbench.h
+++ b/src/regexbench.h
@@ -10,11 +10,12 @@ class Engine;
 class PcapSource;
 
 struct MatchResult {
-  MatchResult() : nmatches(0) {}
+  MatchResult() : nmatches(0), nmatched_pkts(0) {}
 
   struct timeval udiff;
   struct timeval sdiff;
   size_t nmatches;
+  size_t nmatched_pkts;
 };
 
 struct MatchMeta {


### PR DESCRIPTION
regexbench now reports more matching info. It also save the reports to a json format file named `JsonOutput.txt` for later processing. 
