### PR TITLE
Refine Engine interface

### DIFF
--- a/src/Engine.h
+++ b/src/Engine.h
@@ -15,8 +15,7 @@ public:
   virtual void compile(const std::vector<Rule> &) {}
   virtual void init(size_t) {}
   virtual void load(const std::string &) {}
-  virtual size_t match(const char *, size_t) = 0;
-  virtual size_t match(const char *, size_t, size_t) { return 0; }
+  virtual size_t match(const char *, size_t, size_t) = 0;
 };
 
 } // namespace regexbench

--- a/src/HyperscanEngine.cpp
+++ b/src/HyperscanEngine.cpp
@@ -59,5 +59,5 @@ size_t HyperscanEngine::match(const char *data, size_t len, size_t) {
   size_t nmatches = 0;
   hs_scan(db, data, static_cast<unsigned>(len), 0, scratch,
           onMatch, &nmatches);
-  return nmatches;
+  return nmatches > 0;
 }

--- a/src/HyperscanEngine.cpp
+++ b/src/HyperscanEngine.cpp
@@ -55,7 +55,7 @@ void HyperscanEngine::compile(const std::vector<Rule> &rules) {
     throw std::bad_alloc();
 }
 
-size_t HyperscanEngine::match(const char *data, size_t len) {
+size_t HyperscanEngine::match(const char *data, size_t len, size_t) {
   size_t nmatches = 0;
   hs_scan(db, data, static_cast<unsigned>(len), 0, scratch,
           onMatch, &nmatches);

--- a/src/HyperscanEngine.h
+++ b/src/HyperscanEngine.h
@@ -30,7 +30,7 @@ public:
   }
 
   virtual void compile(const std::vector<Rule> &);
-  virtual size_t match(const char *, size_t);
+  virtual size_t match(const char *, size_t, size_t);
 
 private:
   hs_database_t *db;

--- a/src/PCRE2Engine.cpp
+++ b/src/PCRE2Engine.cpp
@@ -17,7 +17,7 @@ void PCRE2Engine::compile(const std::vector<Rule> &rules) {
   }
 }
 
-size_t PCRE2Engine::match(const char *data, size_t len) {
+size_t PCRE2Engine::match(const char *data, size_t len, size_t) {
   for (const auto &re : res) {
     int rc = pcre2_match(re->re,
                          reinterpret_cast<PCRE2_SPTR>(data),

--- a/src/PCRE2Engine.cpp
+++ b/src/PCRE2Engine.cpp
@@ -25,7 +25,7 @@ size_t PCRE2Engine::match(const char *data, size_t len, size_t) {
                          PCRE2_NOTEMPTY,
                          re->mdata, nullptr);
     if (rc >=0)
-      return static_cast<size_t>(rc);
+      return 1;
   }
   return 0;
 }

--- a/src/PCRE2Engine.h
+++ b/src/PCRE2Engine.h
@@ -15,7 +15,7 @@ public:
   virtual ~PCRE2Engine() = default;
 
   virtual void compile(const std::vector<Rule> &);
-  virtual size_t match(const char *, size_t);
+  virtual size_t match(const char *, size_t, size_t);
 
 protected:
   struct PCRE2_DATA {

--- a/src/RE2Engine.cpp
+++ b/src/RE2Engine.cpp
@@ -27,7 +27,7 @@ void RE2Engine::compile(const std::vector<Rule> &rules) {
   }
 }
 
-size_t RE2Engine::match(const char *data, size_t len) {
+size_t RE2Engine::match(const char *data, size_t len, size_t) {
   len = 0;
   for (const auto &re : res) {
     if (re2::RE2::PartialMatch(data, *re)) {

--- a/src/RE2Engine.h
+++ b/src/RE2Engine.h
@@ -15,7 +15,7 @@ public:
   virtual ~RE2Engine() = default;
 
   virtual void compile(const std::vector<Rule> &);
-  virtual size_t match(const char *, size_t);
+  virtual size_t match(const char *, size_t, size_t);
 private:
   std::vector<std::unique_ptr<re2::RE2>> res;
 };

--- a/src/REmatchEngine.cpp
+++ b/src/REmatchEngine.cpp
@@ -53,7 +53,7 @@ void REmatchAutomataEngine::load(const std::string &filename) {
     throw std::bad_alloc();
 }
 
-size_t REmatchAutomataEngine::match(const char *data, size_t len) {
+size_t REmatchAutomataEngine::match(const char *data, size_t len, size_t) {
   MATCHER_SINGLE_CLEAN(matcher);
   mregexec_single(txtbl, data, len, 1, regmatch, matcher, flow);
   return matcher->matches;

--- a/src/REmatchEngine.h
+++ b/src/REmatchEngine.h
@@ -16,7 +16,7 @@ public:
 
   virtual void compile(const std::vector<Rule> &);
   virtual void load(const std::string &);
-  virtual size_t match(const char *, size_t);
+  virtual size_t match(const char *, size_t, size_t);
 
 private:
   mregflow_t *flow;
@@ -34,7 +34,7 @@ public:
   virtual ~REmatchSOEngine();
 
   virtual void load(const std::string &);
-  virtual size_t match(const char *data, size_t len) {
+  virtual size_t match(const char *data, size_t len, size_t) {
     return run(data, len, ctx);
   }
 

--- a/src/match.cpp
+++ b/src/match.cpp
@@ -88,27 +88,6 @@ std::vector<MatchMeta> regexbench::buildMatchMeta(const PcapSource &src,
   return matcher_info;
 }
 
-MatchResult regexbench::sessionMatch(Engine &engine, const PcapSource &src,
-                              long repeat, const std::vector<MatchMeta> &meta) {
-  struct rusage begin, end;
-  MatchResult result;
-  getrusage(RUSAGE_SELF, &begin);
-  for (long i = 0; i < repeat; ++i) {
-    for (size_t j = 0; j < src.getNumberOfPackets(); j++) {
-      auto matches = engine.match(src[j].data() + meta[j].oft, meta[j].len, meta[j].sid);
-
-      if (matches) {
-        result.nmatches += matches;
-        result.nmatched_pkts++;
-      }
-    }
-  }
-  getrusage(RUSAGE_SELF, &end);
-  timersub(&(end.ru_utime), &(begin.ru_utime), &result.udiff);
-  timersub(&(end.ru_stime), &(begin.ru_stime), &result.sdiff);
-  return result;
-}
-
 MatchResult regexbench::match(Engine &engine, const PcapSource &src,
                               long repeat, const std::vector<MatchMeta> &meta) {
   struct rusage begin, end;
@@ -117,7 +96,6 @@ MatchResult regexbench::match(Engine &engine, const PcapSource &src,
   for (long i = 0; i < repeat; ++i) {
     for (size_t j = 0; j < src.getNumberOfPackets(); j++) {
       auto matches = engine.match(src[j].data() + meta[j].oft, meta[j].len, meta[j].sid);
-
       if (matches) {
         result.nmatches += matches;
         result.nmatched_pkts++;

--- a/src/regexbench.cpp
+++ b/src/regexbench.cpp
@@ -105,12 +105,8 @@ int main(int argc, const char *argv[]) {
     auto match_info = buildMatchMeta(pcap, nsessions);
     engine->init(nsessions);
 
-    regexbench::MatchResult result;
-    if (args.engine == ENGINE_REMATCH && args.rematch_session) {
-      result = sessionMatch(*engine, pcap, args.repeat, match_info);
-    } else {
-      result = match(*engine, pcap, args.repeat, match_info);
-    }
+    regexbench::MatchResult result =
+      match(*engine, pcap, args.repeat, match_info);
     boost::property_tree::ptree pt;
     pt.put(prefix + "TotalMatches", result.nmatches);
     pt.put(prefix + "TotalMatchedPackets", result.nmatched_pkts);

--- a/src/regexbench.h
+++ b/src/regexbench.h
@@ -36,8 +36,6 @@ uint32_t getPLOffset(const std::string &);
 std::vector<Rule> loadRules(const std::string &);
 MatchResult match(Engine &, const PcapSource &, long,
                   const std::vector<MatchMeta> &);
-MatchResult sessionMatch(Engine &, const PcapSource &, long,
-                         const std::vector<MatchMeta> &);
 }
 
 #endif // REGEXBENCH_H

--- a/tests/t_session.cpp
+++ b/tests/t_session.cpp
@@ -16,7 +16,7 @@ ATF_TEST_CASE_BODY(session1) {
   regexbench::PcapSource pcap(DATA_DIR "/pcap/session.pcap");
   auto match_info = buildMatchMeta(pcap, nsessions);
   engine.init(nsessions);
-  regexbench::MatchResult result = sessionMatch(engine, pcap, 1, match_info);
+  regexbench::MatchResult result = match(engine, pcap, 1, match_info);
   ATF_REQUIRE_EQ(1, result.nmatches);
 }
 
@@ -29,7 +29,7 @@ ATF_TEST_CASE_BODY(session2) {
   auto match_info = buildMatchMeta(pcap, nsessions);
   ATF_REQUIRE_EQ(4, nsessions);
   engine.init(nsessions);
-  regexbench::MatchResult result = sessionMatch(engine, pcap, 1, match_info);
+  regexbench::MatchResult result = match(engine, pcap, 1, match_info);
   ATF_REQUIRE_EQ(2, result.nmatches);
 }
 


### PR DESCRIPTION
Refine Engine interface, remove _sessionMatch_, solve issue of reporting incorrect number of matches
