### PR TITLE
Fix pcre2 concat

### DIFF
--- a/src/PCRE2Engine.cpp
+++ b/src/PCRE2Engine.cpp
@@ -4,7 +4,7 @@ using namespace regexbench;
 
 void PCRE2Engine::init(size_t mode) { isConcat = mode; }
 
-void PCRE2Engine::concatCompile(std::string ruleStr, size_t nrules,
+void PCRE2Engine::binaryCompile(std::string ruleStr, size_t nrules,
                                 size_t offset, uint32_t ops) {
   PCRE2_SIZE erroffset = 0;
   int errcode = 0;
@@ -16,8 +16,8 @@ void PCRE2Engine::concatCompile(std::string ruleStr, size_t nrules,
       throw std::runtime_error("PCRE2 Compile failed.");
 
     auto splitOft = ruleOffset[offset + nrules / 2] - ruleOffset[offset];
-    concatCompile(ruleStr.substr(0, splitOft - 1), nrules / 2, offset, ops);
-    concatCompile(ruleStr.substr(splitOft), nrules / 2 + (nrules & 1),
+    binaryCompile(ruleStr.substr(0, splitOft - 1), nrules / 2, offset, ops);
+    binaryCompile(ruleStr.substr(splitOft), nrules / 2 + (nrules & 1),
                   offset + nrules / 2, 0);
   } else {
     auto mdata = pcre2_match_data_create_from_pattern(re, nullptr);
@@ -30,7 +30,7 @@ void PCRE2Engine::compile(const std::vector<Rule> &rules) {
   if (isConcat) {
     auto ruleSize = rules.size();
     auto ops = buildRuleOffset(const_cast<std::vector<Rule> &>(rules));
-    concatCompile(rules[0].getRegexp(), ruleSize, 0, ops);
+    binaryCompile(rules[0].getRegexp(), ruleSize, 0, ops);
     return;
   }
 

--- a/src/PCRE2Engine.cpp
+++ b/src/PCRE2Engine.cpp
@@ -2,13 +2,45 @@
 
 using namespace regexbench;
 
+void PCRE2Engine::init(size_t mode) { isConcat = mode; }
+
+void PCRE2Engine::concatCompile(std::string ruleStr, size_t nrules,
+                                size_t offset, uint32_t ops) {
+  PCRE2_SIZE erroffset = 0;
+  int errcode = 0;
+  auto re =
+      pcre2_compile(reinterpret_cast<PCRE2_SPTR>(ruleStr.data()),
+                    PCRE2_ZERO_TERMINATED, ops, &errcode, &erroffset, nullptr);
+  if (re == nullptr) {
+    if (nrules == 1 || errcode != 120)
+      throw std::runtime_error("PCRE2 Compile failed.");
+
+    auto splitOft = ruleOffset[offset + nrules / 2] - ruleOffset[offset];
+    concatCompile(ruleStr.substr(0, splitOft - 1), nrules / 2, offset, ops);
+    concatCompile(ruleStr.substr(splitOft), nrules / 2 + (nrules & 1),
+                  offset + nrules / 2, 0);
+  } else {
+    auto mdata = pcre2_match_data_create_from_pattern(re, nullptr);
+    res.push_back(std::make_unique<PCRE2Engine::PCRE2_DATA>(re, mdata));
+    return;
+  }
+}
+
 void PCRE2Engine::compile(const std::vector<Rule> &rules) {
+  if (isConcat) {
+    auto ruleSize = rules.size();
+    auto ops = buildRuleOffset(const_cast<std::vector<Rule> &>(rules));
+    concatCompile(rules[0].getRegexp(), ruleSize, 0, ops);
+    return;
+  }
+
   PCRE2_SIZE erroffset = 0;
   int errcode = 0;
   for (const auto &rule : rules) {
-    auto re = pcre2_compile(reinterpret_cast<PCRE2_SPTR>(rule.getRegexp().data()),
-                         PCRE2_ZERO_TERMINATED, rule.getPCRE2Options(),
-                         &errcode, &erroffset, nullptr);
+    auto re =
+        pcre2_compile(reinterpret_cast<PCRE2_SPTR>(rule.getRegexp().data()),
+                      PCRE2_ZERO_TERMINATED, rule.getPCRE2Options(), &errcode,
+                      &erroffset, nullptr);
     if (re == nullptr)
       throw std::runtime_error("PCRE2 Compile failed.");
     auto mdata = pcre2_match_data_create_from_pattern(re, nullptr);
@@ -18,25 +50,24 @@ void PCRE2Engine::compile(const std::vector<Rule> &rules) {
 
 size_t PCRE2Engine::match(const char *data, size_t len, size_t) {
   for (const auto &re : res) {
-    int rc = pcre2_match(re->re,
-                         reinterpret_cast<PCRE2_SPTR>(data),
-                         len, 0, PCRE2_NOTEMPTY_ATSTART |
-                         PCRE2_NOTEMPTY,
-                         re->mdata, nullptr);
-    if (rc >=0)
+    int rc = pcre2_match(re->re, reinterpret_cast<PCRE2_SPTR>(data), len, 0,
+                         PCRE2_NOTEMPTY_ATSTART | PCRE2_NOTEMPTY, re->mdata,
+                         nullptr);
+    if (rc >= 0)
       return 1;
   }
   return 0;
 }
 
-void  PCRE2JITEngine::compile(const std::vector<Rule> &rules) {
+void PCRE2JITEngine::compile(const std::vector<Rule> &rules) {
   PCRE2_SIZE erroffset = 0;
   int errcode = 0;
 
   for (const auto &rule : rules) {
-    auto re = pcre2_compile(reinterpret_cast<PCRE2_SPTR>(rule.getRegexp().data()),
-                         PCRE2_ZERO_TERMINATED, rule.getPCRE2Options(),
-                         &errcode, &erroffset, nullptr);
+    auto re =
+        pcre2_compile(reinterpret_cast<PCRE2_SPTR>(rule.getRegexp().data()),
+                      PCRE2_ZERO_TERMINATED, rule.getPCRE2Options(), &errcode,
+                      &erroffset, nullptr);
     if (re == nullptr)
       throw std::runtime_error("PCRE2 Compile failed.");
 
@@ -47,4 +78,23 @@ void  PCRE2JITEngine::compile(const std::vector<Rule> &rules) {
     auto mdata = pcre2_match_data_create_from_pattern(re, nullptr);
     res.push_back(std::make_unique<PCRE2Engine::PCRE2_DATA>(re, mdata));
   }
+}
+
+uint32_t PCRE2Engine::buildRuleOffset(std::vector<Rule> &rules) {
+  uint32_t ops = 0;
+  size_t ruleOft = 0;
+  std::string concatResult;
+  for (const auto &rule : rules) {
+    concatResult += "(";
+    concatResult += rule.getRegexp();
+    concatResult += ")|";
+    ops |= rule.getPCRE2Options();
+    ruleOffset.emplace_back(ruleOft);
+    ruleOft = concatResult.size();
+  }
+
+  rules.clear();
+  concatResult.resize(concatResult.size() - 1);
+  rules.emplace_back(Rule(concatResult, 0, ops));
+  return ops;
 }

--- a/src/PCRE2Engine.cpp
+++ b/src/PCRE2Engine.cpp
@@ -60,23 +60,13 @@ size_t PCRE2Engine::match(const char *data, size_t len, size_t) {
 }
 
 void PCRE2JITEngine::compile(const std::vector<Rule> &rules) {
-  PCRE2_SIZE erroffset = 0;
-  int errcode = 0;
+  PCRE2Engine::compile(rules);
 
-  for (const auto &rule : rules) {
-    auto re =
-        pcre2_compile(reinterpret_cast<PCRE2_SPTR>(rule.getRegexp().data()),
-                      PCRE2_ZERO_TERMINATED, rule.getPCRE2Options(), &errcode,
-                      &erroffset, nullptr);
-    if (re == nullptr)
-      throw std::runtime_error("PCRE2 Compile failed.");
-
-    errcode = pcre2_jit_compile(re, PCRE2_JIT_COMPLETE);
+  for (auto &re : res) {
+    auto a = re->re;
+    int errcode = ::pcre2_jit_compile(a, PCRE2_JIT_COMPLETE);
     if (errcode < 0)
       throw std::runtime_error("PCRE2 JIT compile failed.");
-
-    auto mdata = pcre2_match_data_create_from_pattern(re, nullptr);
-    res.push_back(std::make_unique<PCRE2Engine::PCRE2_DATA>(re, mdata));
   }
 }
 

--- a/src/PCRE2Engine.h
+++ b/src/PCRE2Engine.h
@@ -32,7 +32,7 @@ protected:
   };
 
   uint32_t buildRuleOffset(std::vector<Rule> &);
-  void concatCompile(std::string, size_t, size_t, uint32_t);
+  void binaryCompile(std::string, size_t, size_t, uint32_t);
   std::vector<std::unique_ptr<PCRE2_DATA>> res;
   std::vector<size_t> ruleOffset;
   size_t isConcat;

--- a/src/PCRE2Engine.h
+++ b/src/PCRE2Engine.h
@@ -15,20 +15,27 @@ public:
   virtual ~PCRE2Engine() = default;
 
   virtual void compile(const std::vector<Rule> &);
+  virtual void init(size_t);
   virtual size_t match(const char *, size_t, size_t);
 
 protected:
   struct PCRE2_DATA {
     pcre2_code *re;
     pcre2_match_data *mdata;
-    PCRE2_DATA(pcre2_code *re_, pcre2_match_data *mdata_) : re{re_}, mdata{mdata_} {}
+    PCRE2_DATA(pcre2_code *re_, pcre2_match_data *mdata_)
+        : re{re_}, mdata{mdata_} {}
     ~PCRE2_DATA() {
       pcre2_code_free(re);
       pcre2_match_data_free(mdata);
     }
+    void compileRule();
   };
 
+  uint32_t buildRuleOffset(std::vector<Rule> &);
+  void concatCompile(std::string, size_t, size_t, uint32_t);
   std::vector<std::unique_ptr<PCRE2_DATA>> res;
+  std::vector<size_t> ruleOffset;
+  size_t isConcat;
 };
 
 class PCRE2JITEngine : public PCRE2Engine {

--- a/src/Rule.cpp
+++ b/src/Rule.cpp
@@ -140,20 +140,3 @@ std::vector<Rule> regexbench::loadRules(std::istream &is) {
   }
   return rules;
 }
-
-void regexbench::concatRules(std::vector<Rule> &rules) {
-  std::string concatResult;
-  uint32_t ops = 0;
-  for (const auto &rule : rules) {
-    concatResult += "(";
-    concatResult += rule.getRegexp();
-    concatResult += ")|";
-    ops |= rule.getPCRE2Options();
-  }
-
-  rules.clear();
-
-  // call resize to remove the tailing '|' character
-  concatResult.resize(concatResult.size() - 1);
-  rules.emplace_back(Rule(concatResult, 0, ops));
-}

--- a/src/Rule.h
+++ b/src/Rule.h
@@ -42,8 +42,6 @@ private:
 };
 
 std::vector<Rule> loadRules(std::istream &);
-void concatRules(std::vector<Rule> &);
-
 } // namespace regexbench
 
 #endif

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -7,32 +7,26 @@ configure_file(${CMAKE_CURRENT_SOURCE_DIR}/Kyuafile.in
 
 add_definitions(-DDATA_DIR="${CMAKE_CURRENT_SOURCE_DIR}")
 
-add_executable(t_metadata t_metadata.cpp
-  ../src/match.cpp ../src/PcapSource.cpp ../src/Rule.cpp ../src/Session.cpp)
-target_link_libraries(t_metadata ${ATF_LIB} ${PCAP_LIB})
+add_library(regexbench_lib STATIC ../src/match.cpp
+  ../src/PcapSource.cpp ../src/Rule.cpp ../src/Session.cpp ../src/Engine.cpp)
 
-add_executable(t_session t_session.cpp ../src/Engine.cpp
-  ../src/match.cpp ../src/PcapSource.cpp ../src/Rule.cpp ../src/Session.cpp)
-target_link_libraries(t_session engines ${ATF_LIB} ${PCAP_LIB})
-if(PCRE2_LIB)
-  target_link_libraries(t_session ${PCRE2_LIB})
-endif()
-if(REMATCHCOMP_LIB)
-  target_link_libraries(t_session ${REMATCHCOMP_LIB})
-endif()
-if(REMATCHEXEC_LIB)
-  target_link_libraries(t_session ${REMATCHEXEC_LIB})
+add_executable(t_metadata t_metadata.cpp)
+target_link_libraries(t_metadata ${ATF_LIB} ${PCAP_LIB} regexbench_lib)
+
+if(REMATCHCOMP_LIB AND REMATCHEXEC_LIB AND PCRE2_LIB)
+  add_executable(t_session t_session.cpp)
+  target_link_libraries(t_session engines ${ATF_LIB} ${PCAP_LIB} ${PCRE2_LIB}
+    ${REMATCHCOMP_LIB} ${REMATCHEXEC_LIB} regexbench_lib)
 endif()
 
-add_executable(t_re2 t_re2.cpp ../src/Engine.cpp
-  ../src/match.cpp ../src/PcapSource.cpp ../src/Rule.cpp ../src/Session.cpp)
-target_link_libraries(t_re2 engines ${ATF_LIB} ${PCAP_LIB} ${RE2_LIB})
+if(RE2_LIB)
+  add_executable(t_re2 t_re2.cpp)
+  target_link_libraries(t_re2 engines ${ATF_LIB} ${PCAP_LIB} ${RE2_LIB} regexbench_lib)
+endif()
 
-add_executable(t_option t_option.cpp ${ENGINE_SRCS}
-  ../src/match.cpp
-  ../src/PcapSource.cpp ../src/Rule.cpp ../src/Session.cpp)
+add_executable(t_option t_option.cpp ${ENGINE_SRCS})
 target_link_libraries(t_option
-  engines ${ATF_LIB} ${PCAP_LIB} ${Boost_LIBRARIES})
+  engines ${ATF_LIB} ${PCAP_LIB} ${Boost_LIBRARIES} regexbench_lib)
 if(HYPERSCAN_LIB)
   target_link_libraries(t_option ${HYPERSCAN_LIB})
 endif()
@@ -42,9 +36,6 @@ endif()
 if(RE2_LIB)
   target_link_libraries(t_option ${RE2_LIB})
 endif()
-if(REMATCHCOMP_LIB)
-  target_link_libraries(t_option ${REMATCHCOMP_LIB})
-endif()
-if(REMATCHEXEC_LIB)
-  target_link_libraries(t_option ${REMATCHEXEC_LIB})
+if(REMATCHCOMP_LIB AND REMATCHEXEC_LIB)
+  target_link_libraries(t_option ${REMATCHCOMP_LIB} ${REMATCHEXEC_LIB})
 endif()

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -26,7 +26,7 @@ endif()
 
 add_executable(t_re2 t_re2.cpp ../src/Engine.cpp
   ../src/match.cpp ../src/PcapSource.cpp ../src/Rule.cpp ../src/Session.cpp)
-target_link_libraries(t_re2 engines ${ATF_LIB} ${PCAP_LIB})
+target_link_libraries(t_re2 engines ${ATF_LIB} ${PCAP_LIB} ${RE2_LIB})
 
 add_executable(t_option t_option.cpp ${ENGINE_SRCS}
   ../src/match.cpp


### PR DESCRIPTION
Resolve the issue that pcre2 fails to handle a large rule. The solution is to use divide and conquer to reduce the rule size to half and try the rule compilation. if succeed, save the compiled rule, otherwise divide further. 
