### PR TITLE
Report failed rules

### DIFF
--- a/src/BoostEngine.cpp
+++ b/src/BoostEngine.cpp
@@ -1,8 +1,11 @@
+#include <sstream>
+
 #include "BoostEngine.h"
 
 using namespace regexbench;
 
 void BoostEngine::compile(const std::vector<Rule> &rules) {
+  std::stringstream msg;
   for (const auto &rule : rules) {
     boost::regex_constants::syntax_option_type op =
         boost::regex_constants::optimize;
@@ -14,8 +17,18 @@ void BoostEngine::compile(const std::vector<Rule> &rules) {
       op |= boost::regex_constants::mod_s;
     }
 
-    auto re = std::make_unique<boost::regex>(rule.getRegexp().data());
+    std::unique_ptr<boost::regex> re;
+    try {
+      re = std::make_unique<boost::regex>(rule.getRegexp().data());
+    } catch (...) {
+      msg << rule.getID() << " ";
+      continue;
+    }
     res.push_back(std::move(re));
+  }
+  if (msg.str().size()) {
+    std::runtime_error error(msg.str());
+    throw error;
   }
 }
 

--- a/src/BoostEngine.cpp
+++ b/src/BoostEngine.cpp
@@ -21,7 +21,7 @@ void BoostEngine::compile(const std::vector<Rule> &rules) {
     try {
       re = std::make_unique<boost::regex>(rule.getRegexp().data());
     } catch (...) {
-      msg << rule.getID() << " ";
+      msg << rule.getID() << " " << rule.getRegexp() << "\n";
       continue;
     }
     res.push_back(std::move(re));

--- a/src/BoostEngine.cpp
+++ b/src/BoostEngine.cpp
@@ -17,15 +17,13 @@ void BoostEngine::compile(const std::vector<Rule> &rules) {
       op |= boost::regex_constants::mod_s;
     }
 
-    std::unique_ptr<boost::regex> re;
     try {
-      re = std::make_unique<boost::regex>(rule.getRegexp());
+      res.emplace_back(std::make_unique<boost::regex>(rule.getRegexp()));
     } catch (const std::exception &e) {
       msg << "id: " << rule.getID() << " " << e.what() << " rule:"
           << rule.getRegexp() << "\n";
       continue;
     }
-    res.push_back(std::move(re));
   }
   if (msg.str().size()) {
     std::runtime_error error(msg.str());

--- a/src/BoostEngine.cpp
+++ b/src/BoostEngine.cpp
@@ -19,9 +19,10 @@ void BoostEngine::compile(const std::vector<Rule> &rules) {
 
     std::unique_ptr<boost::regex> re;
     try {
-      re = std::make_unique<boost::regex>(rule.getRegexp().data());
-    } catch (...) {
-      msg << rule.getID() << " " << rule.getRegexp() << "\n";
+      re = std::make_unique<boost::regex>(rule.getRegexp());
+    } catch (const std::exception &e) {
+      msg << "id: " << rule.getID() << " " << e.what() << " rule:"
+          << rule.getRegexp() << "\n";
       continue;
     }
     res.push_back(std::move(re));

--- a/src/CPPEngine.cpp
+++ b/src/CPPEngine.cpp
@@ -15,9 +15,10 @@ void CPPEngine::compile(const std::vector<Rule> &rules) {
 
     std::unique_ptr<std::regex> re;
     try {
-      re = std::make_unique<std::regex>(rule.getRegexp().data(), op);
-    } catch(...) {
-      msg << rule.getID() << " " << rule.getRegexp() <<"\n";
+      re = std::make_unique<std::regex>(rule.getRegexp(), op);
+    } catch(const std::exception &e) {
+      msg << "id: " << rule.getID() << " " << e.what() << " rule:"
+          << rule.getRegexp() << "\n";
       continue;
     }
     res.push_back(std::move(re));

--- a/src/CPPEngine.cpp
+++ b/src/CPPEngine.cpp
@@ -13,15 +13,13 @@ void CPPEngine::compile(const std::vector<Rule> &rules) {
       op |= std::regex_constants::icase;
     }
 
-    std::unique_ptr<std::regex> re;
     try {
-      re = std::make_unique<std::regex>(rule.getRegexp(), op);
+      res.emplace_back(std::make_unique<std::regex>(rule.getRegexp(), op));
     } catch(const std::exception &e) {
       msg << "id: " << rule.getID() << " " << e.what() << " rule:"
           << rule.getRegexp() << "\n";
       continue;
     }
-    res.push_back(std::move(re));
   }
   if (msg.str().size()) {
     std::runtime_error error(msg.str());

--- a/src/CPPEngine.cpp
+++ b/src/CPPEngine.cpp
@@ -1,8 +1,11 @@
+#include <sstream>
+
 #include "CPPEngine.h"
 
 using namespace regexbench;
 
 void CPPEngine::compile(const std::vector<Rule> &rules) {
+  std::stringstream msg;
   for (const auto &rule : rules) {
     std::regex_constants::syntax_option_type op;
 
@@ -10,8 +13,18 @@ void CPPEngine::compile(const std::vector<Rule> &rules) {
       op |= std::regex_constants::icase;
     }
 
-    auto re = std::make_unique<std::regex>(rule.getRegexp().data(), op);
+    std::unique_ptr<std::regex> re;
+    try {
+      re = std::make_unique<std::regex>(rule.getRegexp().data(), op);
+    } catch(...) {
+      msg << rule.getID() << " ";
+      continue;
+    }
     res.push_back(std::move(re));
+  }
+  if (msg.str().size()) {
+    std::runtime_error error(msg.str());
+    throw error;
   }
 }
 

--- a/src/CPPEngine.cpp
+++ b/src/CPPEngine.cpp
@@ -17,7 +17,7 @@ void CPPEngine::compile(const std::vector<Rule> &rules) {
     try {
       re = std::make_unique<std::regex>(rule.getRegexp().data(), op);
     } catch(...) {
-      msg << rule.getID() << " ";
+      msg << rule.getID() << " " << rule.getRegexp() <<"\n";
       continue;
     }
     res.push_back(std::move(re));

--- a/src/HyperscanEngine.cpp
+++ b/src/HyperscanEngine.cpp
@@ -37,7 +37,7 @@ void HyperscanEngine::reportFailedRules(const std::vector<Rule> &rules) {
     auto result = hs_compile(rule.getRegexp().data(), flag,
                              HS_MODE_BLOCK, &platform, &db, &err);
     if (result != HS_SUCCESS) {
-      msg << rule.getID() << ", ";
+      msg << rule.getID() << " " << rule.getRegexp() << "\n";
     }
   }
   if (msg.str().size()) {

--- a/src/HyperscanEngine.cpp
+++ b/src/HyperscanEngine.cpp
@@ -37,7 +37,9 @@ void HyperscanEngine::reportFailedRules(const std::vector<Rule> &rules) {
     auto result = hs_compile(rule.getRegexp().data(), flag,
                              HS_MODE_BLOCK, &platform, &db, &err);
     if (result != HS_SUCCESS) {
-      msg << rule.getID() << " " << rule.getRegexp() << "\n";
+      msg << "id: " << rule.getID() << " " << err->message << " rule:"
+          << rule.getRegexp() << "\n";
+      hs_free_compile_error(err);
     }
   }
   if (msg.str().size()) {

--- a/src/HyperscanEngine.cpp
+++ b/src/HyperscanEngine.cpp
@@ -1,3 +1,4 @@
+#include <iostream>
 #include <sstream>
 #include <vector>
 
@@ -24,6 +25,27 @@ HyperscanEngine::~HyperscanEngine() {
   hs_free_scratch(scratch);
 }
 
+void HyperscanEngine::reportFailedRules(const std::vector<Rule> &rules) {
+  std::stringstream msg;
+  hs_compile_error_t *err = nullptr;
+
+  for (const auto &rule : rules) {
+    unsigned flag = HS_FLAG_ALLOWEMPTY;
+    if (rule.isSet(MOD_CASELESS)) flag |= HS_FLAG_CASELESS;
+    if (rule.isSet(MOD_MULTILINE)) flag |= HS_FLAG_MULTILINE;
+    if (rule.isSet(MOD_DOTALL)) flag |= HS_FLAG_DOTALL;
+    auto result = hs_compile(rule.getRegexp().data(), flag,
+                             HS_MODE_BLOCK, &platform, &db, &err);
+    if (result != HS_SUCCESS) {
+      msg << rule.getID() << ", ";
+    }
+  }
+  if (msg.str().size()) {
+    std::runtime_error error(msg.str());
+    throw error;
+  }
+}
+
 void HyperscanEngine::compile(const std::vector<Rule> &rules) {
   std::vector<const char *> exps;
   std::vector<unsigned> flags;
@@ -48,11 +70,7 @@ void HyperscanEngine::compile(const std::vector<Rule> &rules) {
                                  static_cast<unsigned>(exps.size()),
                                  mode, &platform, &db, &err);
   if (result != HS_SUCCESS) {
-    std::stringstream msg;
-    msg << err->message << " (ruleid: " << err->expression << ')';
-    std::runtime_error error(msg.str());
-    hs_free_compile_error(err);
-    throw error;
+    reportFailedRules(rules);
   }
 
   result = hs_alloc_scratch(db, &scratch);

--- a/src/HyperscanEngine.h
+++ b/src/HyperscanEngine.h
@@ -33,6 +33,7 @@ public:
   virtual size_t match(const char *, size_t, size_t);
 
 protected:
+  void reportFailedRules(const std::vector<Rule> &);
   hs_database_t *db;
   hs_scratch_t *scratch;
   hs_platform_info_t platform;

--- a/src/PCRE2Engine.cpp
+++ b/src/PCRE2Engine.cpp
@@ -44,7 +44,7 @@ void PCRE2Engine::compile(const std::vector<Rule> &rules) {
                       PCRE2_ZERO_TERMINATED, rule.getPCRE2Options(), &errcode,
                       &erroffset, nullptr);
     if (re == nullptr) {
-      msg << rule.getID() << " ";
+      msg << rule.getID() << " " << rule.getRegexp() << "\n";
     } else {
       auto mdata = pcre2_match_data_create_from_pattern(re, nullptr);
       res.push_back(std::make_unique<PCRE2Engine::PCRE2_DATA>(re, mdata));
@@ -75,7 +75,7 @@ void PCRE2JITEngine::compile(const std::vector<Rule> &rules) {
     auto a = res[i]->re;
     int errcode = ::pcre2_jit_compile(a, PCRE2_JIT_COMPLETE);
     if (errcode < 0)
-      msg << i << " ";
+      msg << i << " " << rules[i].getRegexp() << "\n";
   }
   if (msg.str().size()) {
     std::runtime_error error(msg.str());

--- a/src/PCRE2Engine.cpp
+++ b/src/PCRE2Engine.cpp
@@ -1,3 +1,4 @@
+#include <sstream>
 #include "PCRE2Engine.h"
 
 using namespace regexbench;
@@ -36,15 +37,22 @@ void PCRE2Engine::compile(const std::vector<Rule> &rules) {
 
   PCRE2_SIZE erroffset = 0;
   int errcode = 0;
+  std::stringstream msg;
   for (const auto &rule : rules) {
     auto re =
         pcre2_compile(reinterpret_cast<PCRE2_SPTR>(rule.getRegexp().data()),
                       PCRE2_ZERO_TERMINATED, rule.getPCRE2Options(), &errcode,
                       &erroffset, nullptr);
-    if (re == nullptr)
-      throw std::runtime_error("PCRE2 Compile failed.");
-    auto mdata = pcre2_match_data_create_from_pattern(re, nullptr);
-    res.push_back(std::make_unique<PCRE2Engine::PCRE2_DATA>(re, mdata));
+    if (re == nullptr) {
+      msg << rule.getID() << " ";
+    } else {
+      auto mdata = pcre2_match_data_create_from_pattern(re, nullptr);
+      res.push_back(std::make_unique<PCRE2Engine::PCRE2_DATA>(re, mdata));
+    }
+  }
+  if (msg.str().size()) {
+    std::runtime_error error(msg.str());
+    throw error;
   }
 }
 
@@ -61,12 +69,17 @@ size_t PCRE2Engine::match(const char *data, size_t len, size_t) {
 
 void PCRE2JITEngine::compile(const std::vector<Rule> &rules) {
   PCRE2Engine::compile(rules);
+  std::stringstream msg;
 
-  for (auto &re : res) {
-    auto a = re->re;
+  for (size_t i = 0; i < res.size(); i++) {
+    auto a = res[i]->re;
     int errcode = ::pcre2_jit_compile(a, PCRE2_JIT_COMPLETE);
     if (errcode < 0)
-      throw std::runtime_error("PCRE2 JIT compile failed.");
+      msg << i << " ";
+  }
+  if (msg.str().size()) {
+    std::runtime_error error(msg.str());
+    throw error;
   }
 }
 

--- a/src/RE2Engine.cpp
+++ b/src/RE2Engine.cpp
@@ -1,8 +1,11 @@
+#include <sstream>
+
 #include "RE2Engine.h"
 
 using namespace regexbench;
 
 void RE2Engine::compile(const std::vector<Rule> &rules) {
+  std::stringstream msg;
   for (const auto &rule : rules) {
     RE2::Options op;
 
@@ -21,8 +24,12 @@ void RE2Engine::compile(const std::vector<Rule> &rules) {
     if (re->ok()) {
       res.push_back(std::move(re));
     } else {
-      throw std::runtime_error("fail to compile rule: " + rule.getRegexp());
+      msg << rule.getID() << " ";
     }
+  }
+  if (msg.str().size()) {
+    std::runtime_error error(msg.str());
+    throw error;
   }
 }
 

--- a/src/REmatchEngine.cpp
+++ b/src/REmatchEngine.cpp
@@ -128,11 +128,11 @@ size_t REmatchAutomataEngineSession::match(const char *pkt, size_t len,
 }
 
 void REmatchAutomataEngineSession::init(size_t nsessions) {
-  parent = mregSession_create_parent(static_cast<uint32_t>(nsessions * 2),
+  parent = mregSession_create_parent(static_cast<uint32_t>(nsessions),
                                      txtbl->nstates);
   child = mregSession_create_child(parent, unit_total);
 
-  for (size_t i = 0; i < nsessions * 2; i++) {
+  for (size_t i = 0; i < nsessions; i++) {
     matcher_t *cur = child->mindex[i];
     if (cur->num_active) {
       if (child->active1 < MNULL) {


### PR DESCRIPTION
This pull request revises the behavior on how to handle the failing rules. Previously the engine halts in the first failure rule, it is not convenient for the user to identify failed rules. On contrast,  it now reports a list of failed rules with rule id, rule self and possible reason.  
