### PR TITLE
add usec to statistical data generated per second for reduce the error od mbps

### DIFF
--- a/src/match.cpp
+++ b/src/match.cpp
@@ -152,6 +152,7 @@ void regexbench::matchThread(Engine* engine, const PcapSource* src, long repeat,
                              MatchResult* result, Logger* logger)
 {
   setAffinity(core, "match");
+  gettimeofday(&(result->begintime), NULL); // Use this time calculate Mbps.
 
   struct rusage begin, end;
   getrusage(RUSAGE_THREAD, &begin);
@@ -191,7 +192,6 @@ std::vector<MatchResult> regexbench::match(Engine& engine,
   std::vector<size_t> defaultCores;
   bool realTime = true;
   uint32_t sec = 0;
-  timeval begin;
 
   std::vector<MatchResult> results;
   if (cores.size() < 2) {
@@ -224,12 +224,10 @@ std::vector<MatchResult> regexbench::match(Engine& engine,
                                   (pLogger ? pLogger.get() : nullptr)));
   }
 
-  gettimeofday(&begin, NULL);
-
   while (realTime) {
     std::this_thread::sleep_for(std::chrono::seconds(1));
     sec++;
-    statistic(sec, begin, results, func, p);
+    statistic(sec, results, func, p);
 
     for (const auto& result : results) {
       if (!result.stop.load()) {
@@ -241,7 +239,7 @@ std::vector<MatchResult> regexbench::match(Engine& engine,
   }
 
   sec++;
-  statistic(sec, begin, results, func, p);
+  statistic(sec, results, func, p);
 
   for (auto& thr : threads)
     thr.join();

--- a/src/match.cpp
+++ b/src/match.cpp
@@ -152,7 +152,6 @@ void regexbench::matchThread(Engine* engine, const PcapSource* src, long repeat,
                              MatchResult* result, Logger* logger)
 {
   setAffinity(core, "match");
-  gettimeofday(&(result->begintime), NULL); // Use this time calculate Mbps.
 
   struct rusage begin, end;
   getrusage(RUSAGE_THREAD, &begin);
@@ -192,6 +191,7 @@ std::vector<MatchResult> regexbench::match(Engine& engine,
   std::vector<size_t> defaultCores;
   bool realTime = true;
   uint32_t sec = 0;
+  timeval begin;
 
   std::vector<MatchResult> results;
   if (cores.size() < 2) {
@@ -224,10 +224,12 @@ std::vector<MatchResult> regexbench::match(Engine& engine,
                                   (pLogger ? pLogger.get() : nullptr)));
   }
 
+  gettimeofday(&begin, NULL);
+
   while (realTime) {
     std::this_thread::sleep_for(std::chrono::seconds(1));
     sec++;
-    statistic(sec, results, func, p);
+    statistic(sec, begin, results, func, p);
 
     for (const auto& result : results) {
       if (!result.stop.load()) {
@@ -239,7 +241,7 @@ std::vector<MatchResult> regexbench::match(Engine& engine,
   }
 
   sec++;
-  statistic(sec, results, func, p);
+  statistic(sec, begin, results, func, p);
 
   for (auto& thr : threads)
     thr.join();

--- a/src/regexbench.h
+++ b/src/regexbench.h
@@ -62,7 +62,7 @@ struct ResultInfo {
 };
 
 struct MatchResult {
-  MatchResult() : stop(false) {}
+  MatchResult() : endtime({0,0}), stop(false) {}
   MatchResult(const MatchResult& s)
   {
     udiff = s.udiff;
@@ -86,6 +86,7 @@ struct MatchResult {
 
   struct timeval udiff;
   struct timeval sdiff;
+  struct timeval endtime;
   struct ResultInfo cur;
   struct ResultInfo old;
   std::atomic_bool stop;
@@ -132,8 +133,9 @@ Arguments init(const std::string& rule_file, const std::string& pcap_file,
                const std::string& affinity = "0", int32_t repeat = 1);
 int exec(Arguments& args, realtimeFunc func = nullptr, void* p = nullptr);
 Arguments parse_options(int argc, const char* argv[]);
-void statistic(const uint32_t sec, std::vector<MatchResult>& results,
-               realtimeFunc func = nullptr, void* p = nullptr);
+void statistic(const uint32_t sec, timeval& begin,
+               std::vector<MatchResult>& results, realtimeFunc func = nullptr,
+               void* p = nullptr);
 std::unique_ptr<Engine> loadEngine(Arguments& args, std::string& prefix,
                                    size_t nsessions);
 }

--- a/src/regexbench.h
+++ b/src/regexbench.h
@@ -62,7 +62,7 @@ struct ResultInfo {
 };
 
 struct MatchResult {
-  MatchResult() : begintime({0, 0}), endtime({0, 0}), stop(false) {}
+  MatchResult() : endtime({0,0}), stop(false) {}
   MatchResult(const MatchResult& s)
   {
     udiff = s.udiff;
@@ -86,7 +86,6 @@ struct MatchResult {
 
   struct timeval udiff;
   struct timeval sdiff;
-  struct timeval begintime;
   struct timeval endtime;
   struct ResultInfo cur;
   struct ResultInfo old;
@@ -134,8 +133,9 @@ Arguments init(const std::string& rule_file, const std::string& pcap_file,
                const std::string& affinity = "0", int32_t repeat = 1);
 int exec(Arguments& args, realtimeFunc func = nullptr, void* p = nullptr);
 Arguments parse_options(int argc, const char* argv[]);
-void statistic(const uint32_t sec, std::vector<MatchResult>& results,
-               realtimeFunc func = nullptr, void* p = nullptr);
+void statistic(const uint32_t sec, timeval& begin,
+               std::vector<MatchResult>& results, realtimeFunc func = nullptr,
+               void* p = nullptr);
 std::unique_ptr<Engine> loadEngine(Arguments& args, std::string& prefix,
                                    size_t nsessions);
 }

--- a/src/regexbench.h
+++ b/src/regexbench.h
@@ -62,7 +62,7 @@ struct ResultInfo {
 };
 
 struct MatchResult {
-  MatchResult() : endtime({0,0}), stop(false) {}
+  MatchResult() : begintime({0, 0}), endtime({0, 0}), stop(false) {}
   MatchResult(const MatchResult& s)
   {
     udiff = s.udiff;
@@ -86,6 +86,7 @@ struct MatchResult {
 
   struct timeval udiff;
   struct timeval sdiff;
+  struct timeval begintime;
   struct timeval endtime;
   struct ResultInfo cur;
   struct ResultInfo old;
@@ -133,9 +134,8 @@ Arguments init(const std::string& rule_file, const std::string& pcap_file,
                const std::string& affinity = "0", int32_t repeat = 1);
 int exec(Arguments& args, realtimeFunc func = nullptr, void* p = nullptr);
 Arguments parse_options(int argc, const char* argv[]);
-void statistic(const uint32_t sec, timeval& begin,
-               std::vector<MatchResult>& results, realtimeFunc func = nullptr,
-               void* p = nullptr);
+void statistic(const uint32_t sec, std::vector<MatchResult>& results,
+               realtimeFunc func = nullptr, void* p = nullptr);
 std::unique_ptr<Engine> loadEngine(Arguments& args, std::string& prefix,
                                    size_t nsessions);
 }

--- a/src/statistic.cpp
+++ b/src/statistic.cpp
@@ -22,7 +22,7 @@ make_statistic(const uint32_t sec, const size_t usec,
 static struct ResultInfo realtime(std::vector<MatchResult>& results);
 static struct ResultInfo total(std::vector<MatchResult>& results);
 
-void regexbench::statistic(const uint32_t sec,
+void regexbench::statistic(const uint32_t sec, timeval& begin,
                            std::vector<MatchResult>& results, realtimeFunc func,
                            void* p)
 {
@@ -38,7 +38,7 @@ void regexbench::statistic(const uint32_t sec,
       break;
     }
 
-    timersub(&(r.endtime), &(r.begintime), &diff);
+    timersub(&(r.endtime), &begin, &diff);
 
     // if sec is less than 0, then already finished before begin time.
     if (diff.tv_sec < 0)
@@ -51,15 +51,11 @@ void regexbench::statistic(const uint32_t sec,
 
   if (usec == 0) {
     timeval end;
+
     gettimeofday(&end, NULL);
+    timersub(&end, &begin, &diff);
 
-    // The first thread (index is 0) is set the time earlier than the other thread.
-    timersub(&end, &(results[0].begintime), &diff);
-
-    for (auto& r : results) {
-      r.begintime = end;
-    }
-
+    begin = end;
     usec = static_cast<size_t>(diff.tv_sec * 1e+6 + diff.tv_usec);
   }
 

--- a/src/statistic.cpp
+++ b/src/statistic.cpp
@@ -22,7 +22,7 @@ make_statistic(const uint32_t sec, const size_t usec,
 static struct ResultInfo realtime(std::vector<MatchResult>& results);
 static struct ResultInfo total(std::vector<MatchResult>& results);
 
-void regexbench::statistic(const uint32_t sec, timeval& begin,
+void regexbench::statistic(const uint32_t sec,
                            std::vector<MatchResult>& results, realtimeFunc func,
                            void* p)
 {
@@ -38,7 +38,7 @@ void regexbench::statistic(const uint32_t sec, timeval& begin,
       break;
     }
 
-    timersub(&(r.endtime), &begin, &diff);
+    timersub(&(r.endtime), &(r.begintime), &diff);
 
     // if sec is less than 0, then already finished before begin time.
     if (diff.tv_sec < 0)
@@ -51,11 +51,15 @@ void regexbench::statistic(const uint32_t sec, timeval& begin,
 
   if (usec == 0) {
     timeval end;
-
     gettimeofday(&end, NULL);
-    timersub(&end, &begin, &diff);
 
-    begin = end;
+    // The first thread (index is 0) is set the time earlier than the other thread.
+    timersub(&end, &(results[0].begintime), &diff);
+
+    for (auto& r : results) {
+      r.begintime = end;
+    }
+
     usec = static_cast<size_t>(diff.tv_sec * 1e+6 + diff.tv_usec);
   }
 

--- a/src/statistic.cpp
+++ b/src/statistic.cpp
@@ -29,9 +29,7 @@ void regexbench::statistic(const uint32_t sec, timeval& begin,
   struct ResultInfo stat = realtime(results);
   struct ResultInfo tstat = total(results);
   double usec = 0.0;
-  timeval end, diff;
-
-  gettimeofday(&end, NULL);
+  timeval diff;
 
   for (auto& r : results) {
     // not ended yet.
@@ -52,7 +50,11 @@ void regexbench::statistic(const uint32_t sec, timeval& begin,
   }
 
   if (usec == 0.0) {
+    timeval end;
+
+    gettimeofday(&end, NULL);
     timersub(&end, &begin, &diff);
+
     begin = end;
     usec = diff.tv_sec * 1e+6 + diff.tv_usec;
   }

--- a/src/statistic.cpp
+++ b/src/statistic.cpp
@@ -17,7 +17,7 @@
 using namespace regexbench;
 
 static std::map<std::string, size_t>
-make_statistic(const uint32_t sec, const double usec,
+make_statistic(const uint32_t sec, const size_t usec,
                const struct ResultInfo& stat, const struct ResultInfo& total);
 static struct ResultInfo realtime(std::vector<MatchResult>& results);
 static struct ResultInfo total(std::vector<MatchResult>& results);
@@ -28,13 +28,13 @@ void regexbench::statistic(const uint32_t sec, timeval& begin,
 {
   struct ResultInfo stat = realtime(results);
   struct ResultInfo tstat = total(results);
-  double usec = 0.0;
+  size_t usec = 0;
   timeval diff;
 
   for (auto& r : results) {
     // not ended yet.
     if (r.endtime.tv_sec == 0 && r.endtime.tv_usec == 0) {
-      usec = 0.0;
+      usec = 0;
       break;
     }
 
@@ -44,19 +44,19 @@ void regexbench::statistic(const uint32_t sec, timeval& begin,
     if (diff.tv_sec < 0)
       continue;
 
-    double m_usec = diff.tv_sec * 1e+6 + diff.tv_usec;
+    size_t m_usec = static_cast<size_t>(diff.tv_sec * 1e+6 + diff.tv_usec);
     if (usec < m_usec)
       usec = m_usec;
   }
 
-  if (usec == 0.0) {
+  if (usec == 0) {
     timeval end;
 
     gettimeofday(&end, NULL);
     timersub(&end, &begin, &diff);
 
     begin = end;
-    usec = diff.tv_sec * 1e+6 + diff.tv_usec;
+    usec = static_cast<size_t>(diff.tv_sec * 1e+6 + diff.tv_usec);
   }
 
   // std::cout << std::fixed << std::setprecision(6) << "usec : " << usec <<
@@ -105,13 +105,13 @@ static struct ResultInfo total(std::vector<MatchResult>& results)
 }
 
 static std::map<std::string, size_t>
-make_statistic(const uint32_t sec, const double usec, const struct ResultInfo& stat,
+make_statistic(const uint32_t sec, const size_t usec, const struct ResultInfo& stat,
                const struct ResultInfo& total)
 {
   std::map<std::string, size_t> m;
 
   m["Sec"] = sec;
-  m["Usec"] = static_cast<size_t>(usec);
+  m["Usec"] = usec;
   m["Matches"] = stat.nmatches;
   m["MatchedPackets"] = stat.nmatched_pkts;
   m["Packets"] = stat.npkts;


### PR DESCRIPTION
When generate Tx (Mbps) graph by Traffic Weaver, the last value is the value created for less than one second. So I added it to solve using usec.