### PR TITLE
Build without pcre2 on Linux

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,6 @@ addons:
       - libboost-regex-dev
       - libboost-system-dev
       - libpcap-dev
-      - libpcre2-dev
 
 script:
   - CXX=/usr/bin/g++-6 CC=/usr/bin/gcc-6 cmake .

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -27,7 +27,7 @@ add_library(engines OBJECT ${ENGINE_SRCS})
 
 set(REGEXBENCH_SRCS match.cpp report.cpp PcapSource.cpp regexbench.cpp Rule.cpp Session.cpp BackgroundJobs.cpp statistic.cpp)
 add_library(rebench $<TARGET_OBJECTS:engines> ${REGEXBENCH_SRCS})
-target_link_libraries(rebench ${Boost_LIBRARIES})
+target_link_libraries(rebench ${Boost_LIBRARIES} ${CMAKE_THREAD_LIBS_INIT})
 
 add_executable(regexbench main.cpp)
 target_link_libraries(regexbench

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -27,6 +27,7 @@ add_library(engines OBJECT ${ENGINE_SRCS})
 
 set(REGEXBENCH_SRCS match.cpp report.cpp PcapSource.cpp regexbench.cpp Rule.cpp Session.cpp BackgroundJobs.cpp statistic.cpp)
 add_library(rebench $<TARGET_OBJECTS:engines> ${REGEXBENCH_SRCS})
+target_link_libraries(rebench ${Boost_LIBRARIES})
 
 add_executable(regexbench main.cpp)
 target_link_libraries(regexbench

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -27,7 +27,7 @@ add_library(engines OBJECT ${ENGINE_SRCS})
 
 set(REGEXBENCH_SRCS match.cpp report.cpp PcapSource.cpp regexbench.cpp Rule.cpp Session.cpp BackgroundJobs.cpp statistic.cpp)
 add_library(rebench $<TARGET_OBJECTS:engines> ${REGEXBENCH_SRCS})
-target_link_libraries(rebench ${Boost_LIBRARIES} ${CMAKE_THREAD_LIBS_INIT})
+target_link_libraries(rebench ${Boost_LIBRARIES} ${PCAP_LIB} ${CMAKE_THREAD_LIBS_INIT})
 
 add_executable(regexbench main.cpp)
 target_link_libraries(regexbench

--- a/src/Rule.cpp
+++ b/src/Rule.cpp
@@ -1,3 +1,4 @@
+#include <cstdint>
 #ifndef NDEBUG
 #include <iostream>
 #endif
@@ -5,8 +6,14 @@
 #include <string>
 
 #include <boost/algorithm/string/trim.hpp>
+#ifdef HAVE_PCRE2
 #define PCRE2_CODE_UNIT_WIDTH 8
 #include <pcre2.h>
+#else
+constexpr uint32_t PCRE2_CASELESS = 0x00000008u;
+constexpr uint32_t PCRE2_DOTALL = 0x00000020u;
+constexpr uint32_t PCRE2_MULTILINE = 0x00000400u;
+#endif
 
 #include "Rule.h"
 


### PR DESCRIPTION
This PR makes regexbench build on Linux without requiring PCRE2.